### PR TITLE
Fix colours on macOS by using the fallback adapter

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ let println = function(line) {
 
     let colorizer = trueColor;
 
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' || process.platform === 'darwin') {
         colorizer = fallbackColor;
     }
 


### PR DESCRIPTION
This fixes issue #3 

This is a screenshot of the app after the fix

![Preview](http://i.imgur.com/4AOAJR0.png)