### PR TITLE
Support 256 colors on Windows 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 "use strict";
 
-const terminal         = require('terminal-kit').terminal;
 const cursor           = require('ansi')(process.stdout);
 const Reader           = require('line-by-line');
-const supportsColor    = require('supports-color');
+const chalk            = require('chalk');
 
 let sleep = null;
 // Because sleep is a native module, depending on the
@@ -45,36 +44,18 @@ let rainbow = function(freq, i) {
     }
 };
 
-let trueColor = function (char, colors) {
-
-    process.stdout.write('\x1b[38;2;' + colors.red + ';' + colors.green + ';' + colors.blue + 'm' + char + '\x1b[0m');
+let colorize = function(char, colors) {
+    process.stdout.write(chalk.rgb(colors.red, colors.green, colors.blue)(char));
 };
 
-let fallbackColor = function (char, colors) {
-
-    // Make sure special chars used by terminal-kit are correctly escaped
-    let escapedChar = char.replace('^', '^^');
-
-    terminal.colorRgb(
-        colors.red,
-        colors.green,
-        colors.blue,
-        escapedChar
-    );
-};
-
-let noColor = function(char, colors) {
-    process.stdout.write(char);
-};
-
-let printlnPlain = function(colorizer, line) {
+let printlnPlain = function(colorize, line) {
 
     for (let i = 0; i < line.length; i++) {
-        colorizer(line[i], rainbow(options.freq, options.seed + i / options.spread));
+        colorize(line[i], rainbow(options.freq, options.seed + i / options.spread));
     }
 };
 
-let printlnAnimated = function(colorizer, line) {
+let printlnAnimated = function(colorize, line) {
 
     if (sleep) {
 
@@ -87,7 +68,7 @@ let printlnAnimated = function(colorizer, line) {
             options.seed += options.spread;
 
             if (j % 2 === 0) {
-                printlnPlain(colorizer, line);
+                printlnPlain(colorize, line);
             }
 
             sleep.usleep(1/options.speed * 500000);
@@ -98,27 +79,17 @@ let printlnAnimated = function(colorizer, line) {
 
     }
 
-    printlnPlain(colorizer, line);
+    printlnPlain(colorize, line);
 };
 
 let println = function(line) {
-  let colorizer = noColor;
-
-  if (supportsColor) {
-    colorizer = fallbackColor;
-  }
-
-  if (supportsColor.has16m) {
-    colorizer = trueColor;
-  }
-
   cursor.show();
 
   if (options.animate) {
     cursor.hide();
-    printlnAnimated(colorizer, line);
+    printlnAnimated(colorize, line);
   } else {
-    printlnPlain(colorizer, line);
+    printlnPlain(colorize, line);
   }
 
   process.stdout.write('\n');

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
   "license": "WTFPL",
   "dependencies": {
     "ansi": "^0.3.0",
+    "chalk": "^2.1.0",
     "line-by-line": "^0.1.3",
     "minimist": "^1.1.1",
-    "multiline": "^1.0.2",
-    "supports-color": "^4.2.0",
-    "terminal-kit": "^0.26.0"
+    "multiline": "^1.0.2"
   },
   "optionalDependencies": {
     "sleep": "^5.0.0"


### PR DESCRIPTION
Replaces the color support detection with chalk, which detects the best supported color mode and does the conversion internally (in fact it uses the very same supports-color library under the hood). Most importantly, this change makes 256 colors work in Windows 10, in recent versions at least.