### PR TITLE
Add a "files" section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "lolcatjs": "cli.js"
   },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
   "bugs": {
     "url": "https://github.com/robertboloc/lolcatjs/issues"
   },


### PR DESCRIPTION
This saves downloading the images in the "assets" directory when the package is installed via npm. If you prefer having them there please just reject this pull request.