### PR TITLE
Fix '-f' Option and lolcatjs on multiple files

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,8 +4,10 @@
 
 var lolcatjs  = require('./');
 var info      = require('./package.json');
+var chalk     = require('chalk');
 var minimist  = require('minimist');
 var multiline = require('multiline');
+var supportsColor = require('supports-color');
 
 var args = minimist(process.argv.slice(2), {
     alias: {
@@ -80,8 +82,9 @@ function version() {
 
 function init(args) {
 
-    if (process.stdout.isTTY || args.force) {
-        lolcatjs.options.colors = true;
+    if (args.force) {
+      chalk.enabled = true;
+      chalk.level = supportsColor.supportsColor({isTTY: true}).level;
     }
 
     if (args.help) {

--- a/cli.js
+++ b/cli.js
@@ -127,21 +127,14 @@ function init(args) {
 
         lolcatjs.fromPipe();
     } else {
-
-        var listenStdin = false;
-
+        var promise = Promise.resolve();
         args._.forEach(function(file) {
-
             if (file === '-') {
-                listenStdin = true;
+                promise = promise.then(() => lolcatjs.fromPipe());
             } else {
-                lolcatjs.fromFile(file);
+                promise = promise.then(() => lolcatjs.fromFile(file));
             }
         });
-
-        if (listenStdin) {
-            lolcatjs.fromPipe();
-        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,6 @@ let options = {
     spread: 8.0,
     // Frequency of the rainbow colors
     freq: 0.3,
-    // To use colors for the output or not.
-    colors: false
 };
 
 let rainbow = function(freq, i) {

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ let fromPipe = function() {
             println(lines[line]);
         }
     });
+    return new Promise(resolve => process.stdin.on('end', resolve));
 };
 
 let fromFile = function(file) {
@@ -116,6 +117,7 @@ let fromFile = function(file) {
         println(line);
         cursor.show();
     });
+    return new Promise(resolve => fileReader.on('end', resolve));
 };
 
 let fromString = function(string) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "chalk": "^2.1.0",
     "line-by-line": "^0.1.3",
     "minimist": "^1.1.1",
-    "multiline": "^1.0.2"
+    "multiline": "^1.0.2",
+    "supports-color": "^5.0.0"
   },
   "optionalDependencies": {
     "sleep": "^5.0.0"


### PR DESCRIPTION
The `-f` wasn't working. It set `lolcatjs.options.colors = true;` but that variable wasn't used after that.

In the lolcat gem, if you did `lolcat <<<"hello" | cat`, there would be no color. However, if you do `lolcat -f <<<"hello" | cat`, you force colors to be enabled. I mimicked that functionality by leveraging `supports-color`, so I don't have to rewrite the terminal color detection code. It's sort of a hack because I use `supportsColor.supportsColor({isTTY: true})` when it expects a stream. `chalk` uses `supports-color` which disables color when `stdout` is not a tty. So the only way to trick `supports-color` is to tell it that we are a tty.

---

`lolcatjs a b` would interleave `a` and `b` because they were printed asynchronously. I fixed it with some `Promise` chaining.
Also, `lolcatjs a - b` would process the pipe at the end, differing from the lolcat gem. This has also been fixed with the `Promise`s.