### PR TITLE
Made it work on newest LTS version of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -g lolcatjs
 
 **Command Line**
 ```javascript
-lolcatjs [OPTION]... [FILE]...
+lolcat [OPTION]... [FILE]...
 
 Concatenate FILE(s), or standard input, to standard output.
 With no FILE, or when FILE is -, read standard input.
@@ -29,9 +29,9 @@ With no FILE, or when FILE is -, read standard input.
           --help, -h:   Show this message
 
 Examples:
-  lolcatjs f - g     Output f's contents, then stdin, then, g's contents.
-  lolcatjs           Copy standard input to standard output.
-  fortune | lolcatjs Display a rainbow cookie.
+  lolcat f - g          Output f's contents, then stdin, then, g's contents.
+  lolcat                Copy standard input to standard output.
+  fortune | lolcat      Display a rainbow cookie.
 ```
 
 **NPM Module**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The rainbow I tastes it",
   "main": "index.js",
   "bin": {
-    "lolcatjs": "cli.js"
+    "lolcat": "cli.js"
   },
   "files": [
     "index.js",
@@ -41,6 +41,6 @@
     "sleep": "^5.0.0"
   },
   "engines": {
-    "node": "^6.9"
+    "node": ">=6.9"
   }
 }


### PR DESCRIPTION
I'm running 8.9.4, so I couldn't install without this change. Node versions should be pretty much backward compatible so I don't see the need to set an upper limit to supported versions. Also adjusted the name of the cli tool - I think it unlikely that someone will have both this and the ruby version installed, so there is no need to avoid a clash. 