### PR TITLE
Update dependencies. Use template literal instead of multiline.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,6 @@ var lolcatjs  = require('./');
 var info      = require('./package.json');
 var chalk     = require('chalk');
 var minimist  = require('minimist');
-var multiline = require('multiline');
 var supportsColor = require('supports-color');
 
 var args = minimist(process.argv.slice(2), {
@@ -28,8 +27,7 @@ function rand(max) {
 }
 
 function help() {
-    var help = multiline(function(){/*
-
+    var help = `
 Usage: lolcatjs [OPTION]... [FILE]...
 
 Concatenate FILE(s), or standard input, to standard output.
@@ -52,9 +50,7 @@ Examples:
 
 Report lolcatjs bugs to <https://github.com/robertboloc/lolcatjs/issues>
 lolcatjs home page: <https://github.com/robertboloc/lolcatjs/>
-Report lolcatjs translation bugs to <http://speaklolcat.com>
-
-    */});
+Report lolcatjs translation bugs to <http://speaklolcat.com>`;
 
     var i     = 20;
     var o     = rand(256);

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ let fromPipe = function() {
             options.seed += 1;
             println(lines[line]);
         }
+        cursor.show();
     });
     return new Promise(resolve => process.stdin.on('end', resolve));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,87 @@
+{
+  "name": "lolcatjs",
+  "version": "2.3.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "line-by-line": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/line-by-line/-/line-by-line-0.1.6.tgz",
+      "integrity": "sha512-MmwVPfOyp0lWnEZ3fBA8Ah4pMFvxO6WgWovqZNu7Y4J0TNnGcsV4S1LzECHbdgqk1hoHc2mFP1Axc37YUqwafg=="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
+    },
+    "sleep": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.1.0.tgz",
+      "integrity": "sha512-Z1x4JjJxsru75Tqn8F4tnOFeEu3HjtITTsumYUiuz54sGKdISgLCek9AUlXlVVrkhltRFhNUsJDJE76SFHTDIQ==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.13.2"
+      }
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,15 +30,14 @@
   },
   "license": "WTFPL",
   "dependencies": {
-    "ansi": "^0.3.0",
-    "chalk": "^2.1.0",
-    "line-by-line": "^0.1.3",
-    "minimist": "^1.1.1",
-    "multiline": "^1.0.2",
-    "supports-color": "^5.0.0"
+    "ansi": "^0.3.1",
+    "chalk": "^3.0.0",
+    "line-by-line": "^0.1.6",
+    "minimist": "^1.2.0",
+    "supports-color": "^7.1.0"
   },
   "optionalDependencies": {
-    "sleep": "^5.0.0"
+    "sleep": "^6.1.0"
   },
   "engines": {
     "node": ">=6.9"


### PR DESCRIPTION
# Problems

## 1
On the latest version of Node, the `sleep` module throws errors during installation. Thus, animation is not available.

![Screen Shot 2020-02-19 at 8 37 07 PM](https://user-images.githubusercontent.com/586779/74895598-af81c900-5357-11ea-9b1d-9dec8509f45b.png)

![Feb-19-2020 21-02-20](https://user-images.githubusercontent.com/586779/74896959-308e8f80-535b-11ea-8139-e03d2c10bb96.gif)

## 2
The `multiline` module is now [deprecated](https://www.npmjs.com/package/multiline) and [the repository](https://github.com/sindresorhus/multiline) is archived. When installed, it gives the following warning:

```
npm WARN deprecated multiline@2.0.0: This was a fun hack, but now we have template literals, so use that instead.
```

## 3
The cursor disappears after printing piped-in input.

![no cursor](https://user-images.githubusercontent.com/586779/74897993-346fe100-535e-11ea-93ea-48637ac0d8fe.gif)

# Solutions

## 1 
Update dependencies to their latest versions.

![Screen Shot 2020-02-19 at 8 51 27 PM](https://user-images.githubusercontent.com/586779/74896340-a98ce780-5359-11ea-9712-918c327db5e3.png)

![animation works](https://user-images.githubusercontent.com/586779/74898016-3fc30c80-535e-11ea-961e-7af049a7905e.gif)

## 2 
Use a template literal instead of `multiline`.

![Screen Shot 2020-02-19 at 8 41 07 PM](https://user-images.githubusercontent.com/586779/74895789-3a62c380-5358-11ea-9ea5-bc533009b743.png)

## 3
Show cursor after printing the piped-in input.

![cursor is back](https://user-images.githubusercontent.com/586779/74897645-574dc580-535d-11ea-9112-f3aa26b39200.gif)