### PR TITLE
feat: put error messages behind flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ var args = minimist(process.argv.slice(2), {
         S: 'seed',
         a: 'animate',
         d: 'duration',
+        D: 'debug',
         s: 'speed'
     }
 });
@@ -41,6 +42,7 @@ With no FILE, or when FILE is -, read standard input.
      --speed, -s <f>:   Animation speed (default: 20.0)
          --force, -f:   Force color even when stdout is not a tty
        --version, -v:   Print version and exit
+         --debug, -D:   Display error messages, if any (default: false)
           --help, -h:   Show this message
 
 Examples:
@@ -71,7 +73,7 @@ function version() {
         lolcatjs.options.seed = rand(256);
     }
 
-    lolcatjs.println('lolcatjs ' + info.version + ' (c) 2015 Robert Marsal');
+    lolcatjs.println('lolcatjs ' + info.version + ' (c) 2015-2023 Robert Marsal');
 
     process.exit();
 }
@@ -114,6 +116,12 @@ function init(args) {
     if (args.speed) {
         lolcatjs.options.speed = args.speed;
     }
+
+    if (args.debug) {
+        lolcatjs.options.debug = Boolean(args.debug);
+    }
+
+    lolcatjs.init();
 
     if (args._.length === 0) {
 

--- a/index.js
+++ b/index.js
@@ -4,15 +4,8 @@ const cursor           = require('ansi')(process.stdout);
 const Reader           = require('line-by-line');
 const chalk            = require('chalk');
 
+// sleep will be loaded by the init function (if available)
 let sleep = null;
-// Because sleep is a native module, depending on the
-// platform of the user, the compilation might fail,
-// in this case fallback, and show no animations.
-try {
-    sleep = require('sleep');
-} catch (error) {
-    console.error('Unable to load the sleep module (no animations available)');
-}
 
 const options = {
     // To animate or not (only works if the sleep module is available)
@@ -27,6 +20,8 @@ const options = {
     spread: 8.0,
     // Frequency of the rainbow colors
     freq: 0.3,
+    // Whether to display error messages or not
+    debug: false,
 };
 
 const rainbow = function(freq, i) {
@@ -132,9 +127,25 @@ const fromString = function(string) {
     });
 };
 
+const init = function() {
+    // Because sleep is a native module, depending on the
+    // platform of the user, the compilation might fail,
+    // in this case fallback, and show no animations.
+    try {
+        sleep = require('sleep');
+    } catch (error) {
+        if (options.debug) {
+            console.error('The sleep module is not available, animations will be disabled.', error);
+        }
+    }
+
+    return null;
+}
+
 exports.options  = options;
 exports.println  = println;
 exports.rainbow  = rainbow;
 exports.fromPipe = fromPipe;
 exports.fromFile = fromFile;
 exports.fromString = fromString;
+exports.init = init;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,86 +1,133 @@
 {
   "name": "lolcatjs",
   "version": "2.4.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/color-name": {
+  "packages": {
+    "": {
+      "name": "lolcatjs",
+      "version": "2.4.1",
+      "license": "WTFPL",
+      "dependencies": {
+        "ansi": "^0.3.1",
+        "chalk": "^3.0.0",
+        "line-by-line": "^0.1.6",
+        "minimist": "^1.2.0",
+        "sleep": "^6.3.0",
+        "supports-color": "^7.1.0"
+      },
+      "bin": {
+        "lolcatjs": "cli.js"
+      },
+      "engines": {
+        "node": ">=6.9"
+      },
+      "optionalDependencies": {
+        "sleep": "^6.3.0"
+      }
+    },
+    "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
-    "ansi": {
+    "node_modules/ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
       "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "requires": {
+      "dependencies": {
         "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
+      "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "line-by-line": {
+    "node_modules/line-by-line": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/line-by-line/-/line-by-line-0.1.6.tgz",
-      "integrity": "sha512-MmwVPfOyp0lWnEZ3fBA8Ah4pMFvxO6WgWovqZNu7Y4J0TNnGcsV4S1LzECHbdgqk1hoHc2mFP1Axc37YUqwafg=="
+      "integrity": "sha512-MmwVPfOyp0lWnEZ3fBA8Ah4pMFvxO6WgWovqZNu7Y4J0TNnGcsV4S1LzECHbdgqk1hoHc2mFP1Axc37YUqwafg==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+    "node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "optional": true
     },
-    "sleep": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.1.0.tgz",
-      "integrity": "sha512-Z1x4JjJxsru75Tqn8F4tnOFeEu3HjtITTsumYUiuz54sGKdISgLCek9AUlXlVVrkhltRFhNUsJDJE76SFHTDIQ==",
+    "node_modules/sleep": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.3.0.tgz",
+      "integrity": "sha512-+WgYl951qdUlb1iS97UvQ01pkauoBK9ML9I/CMPg41v0Ze4EyMlTgFTDDo32iYj98IYqxIjDMRd+L71lawFfpQ==",
+      "hasInstallScript": true,
       "optional": true,
-      "requires": {
-        "nan": "^2.13.2"
+      "dependencies": {
+        "nan": "^2.14.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
       "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-      "requires": {
+      "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "supports-color": "^7.1.0"
   },
   "optionalDependencies": {
-    "sleep": "^6.1.0"
+    "sleep": "^6.3.0"
   },
   "engines": {
     "node": ">=6.9"


### PR DESCRIPTION
Previously users that did not have the `sleep` package installed would always get an error printed in the terminal. With this change that error message is only displayed when the `--debug` flag is set.

Fixes #23 